### PR TITLE
#163309223 Fix returning of all meetups during POST

### DIFF
--- a/app/api/v1/models/meetup_models.py
+++ b/app/api/v1/models/meetup_models.py
@@ -20,7 +20,7 @@ class MeetupData():
         }
 
         self.meetup_records.append(data)
-        return self.meetup_records
+        return data
 
     def view_meetups(self):
         if len(self.meetup_records) == 0:


### PR DESCRIPTION
#### What does this PR do?
* It fixes all previously created meetups being returned 
#### Description of Task to be completed?
* When a meetup is posted all the others are returned which is fixed here. Now only the created 
meetup is returned after creation
#### How should this be manually tested?
* Clone the repository
* Checkout to the `bg-fix-meetups-163309223` branch
* Create a virtual environment:`virtualenv venv`
* Activate the virtual environment: `source/venv/bin/activate`
* Install the dependencies: `pip install -r requirements.txt`
* Test the endpoint with postman
#### What are the relevant pivotal tracker stories?
* [#163309223](https://www.pivotaltracker.com/story/show/163309223 )